### PR TITLE
fixed bug in mum_warmup_steps and num_training_steps

### DIFF
--- a/multimodal_driver.py
+++ b/multimodal_driver.py
@@ -345,8 +345,8 @@ def prep_for_training(num_train_optimization_steps: int):
     optimizer = AdamW(optimizer_grouped_parameters, lr=args.learning_rate)
     scheduler = get_linear_schedule_with_warmup(
         optimizer,
-        num_warmup_steps=num_train_optimization_steps,
-        num_training_steps=args.warmup_proportion * num_train_optimization_steps,
+        num_warmup_steps=args.warmup_proportion * num_train_optimization_steps,
+        num_training_steps=num_train_optimization_steps,
     )
     return model, optimizer, scheduler
 


### PR DESCRIPTION
The assignments to mum_warmup_steps and num_training_steps were interchanged. mum_warmup_steps should be warmup_proportion*num_train_optimization_steps and num_training_steps should be num_train_optimization_steps.